### PR TITLE
Bookworm update, Labels and interop

### DIFF
--- a/eco/eco-chronicler/Dockerfile
+++ b/eco/eco-chronicler/Dockerfile
@@ -4,14 +4,15 @@ COPY        ["./files", "/tmp/files"]
 
 ARG         BUILD_DATE
 
-LABEL       org.label-schema.schema-version="1.0"
-LABEL       org.label-schema.build-date=$BUILD_DATE
-LABEL       org.label-schema.name="ECO Server"
-LABEL       org.label-schema.description="Eco Server container by nidaren."
-LABEL       org.label-schema.url="https://discord.nidaren.net"
-LABEL       org.label-schema.vcs-url="https://github.com/nidaren/docker-images"
-LABEL       org.label-schema.vendor="nidaren"
-LABEL       org.label-schema.version="1.5"
+LABEL       org.opencontainers.image.created=$BUILD_DATE \
+            org.opencontainers.image.authors="Nidaren" \
+            org.opencontainers.image.url="https://discord.nidaren.net" \
+            org.opencontainers.image.documentation="https://github.com/nidaren/docker-images" \
+            org.opencontainers.image.source="https://github.com/nidaren/docker-images" \
+            org.opencontainers.image.version="1.6" \
+            org.opencontainers.image.vendor="Nidaren" \
+            org.opencontainers.image.title="Eco Server Container for Pterodactyl/Pelican" \
+            org.opencontainers.image.description="Contains environment to run various mods for Eco game server."
 
 RUN         dpkg --add-architecture i386 \
             && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \

--- a/eco/eco-chronicler/build-docker-image.sh
+++ b/eco/eco-chronicler/build-docker-image.sh
@@ -1,1 +1,1 @@
-docker build --no-cache=true --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -t nidaren/pterodactyl:eco-chronicler .
+docker build --no-cache --pull --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -t nidaren/pterodactyl:eco-chronicler .

--- a/eco/eco-chronicler/files/entrypoint.sh
+++ b/eco/eco-chronicler/files/entrypoint.sh
@@ -2,7 +2,7 @@
 
 #
 # Copyright (c) 2021 Matthew Penner
-#
+# Copyright (c) 2026 Nidaren
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
@@ -28,8 +28,14 @@ ENDCOLOR="\e[0m"
 CYAN='\033[0;36m'
 YELLOW='\033[0;33m'
 BLUE='\033[0;34m'
+NICEC="\e[38;5;219m"
+NICEC2="\e[38;5;223m"
 
-FILE=/home/container/Mods/Chronicler/SQLite.Interop.dll
+fix_interop() {
+  echo -e "${YELLOW}Checking for${ENDCOLOR} ${GREEN}incompatible${ENDCOLOR} ${YELLOW}files.${ENDCOLOR}"
+  find "$HOME" -type f -name "SQLite.Interop.dll" \
+    -exec sh -c 'echo "Deleting incompatible: $1"; rm "$1"' _ {} \;
+}
 
 # Wait for the container to fully initialize
 sleep 1
@@ -113,8 +119,16 @@ MODIFIED_STARTUP=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
 echo -e ":/home/container$ ${MODIFIED_STARTUP}"
 
 # Run the Server
-if [ -f "$FILE" ]; then
-    echo -e "${YELLOW}Redundant Interlop dll removed from Chronicler.${ENDCOLOR}"
-    rm "$FILE"
-fi
+NID_DEB=$(. /etc/os-release; echo "$NAME")
+NID_DEBVER=$(cat /etc/debian_version)
+NID_DEBEDI=$(. /etc/os-release; echo "$VERSION_CODENAME")
+
+echo -e "${YELLOW}=======================================================${ENDCOLOR}"
+echo -e "Container's OS:     ${GREEN}${NID_DEB}${ENDCOLOR} ${NICE2}${NID_DEBEDI^}${ENDCOLOR}${NICEC} ${NID_DEBVER}${ENDCOLOR}"
+echo -e "Container's Layout: by ${GREEN}nidaren (c) 2026${ENDCOLOR}"
+echo -e "Support link:       ${NICEC}https://discord.nidaren.net${ENDCOLOR}"
+echo -e "${YELLOW}=======================================================${ENDCOLOR}"
+fix_interop
+
+echo -e "${NICEC}Server will now start.${ENDCOLOR}"
 eval ${MODIFIED_STARTUP}

--- a/eco/eco-chronicler/push-docker-image.sh
+++ b/eco/eco-chronicler/push-docker-image.sh
@@ -1,1 +1,1 @@
-docker push nidaren/pterodactyl:eco-chronicler
+docker push nidaren/pterodactyl:eco-chronicler-staging

--- a/eco/environment/Dockerfile
+++ b/eco/environment/Dockerfile
@@ -4,14 +4,15 @@ COPY        ["./files", "/tmp/files"]
 
 ARG         BUILD_DATE
 
-LABEL       org.label-schema.schema-version="1.0"
-LABEL       org.label-schema.build-date=$BUILD_DATE
-LABEL       org.label-schema.name="ECO Server"
-LABEL       org.label-schema.description="Eco Server container by nidaren."
-LABEL       org.label-schema.url="https://discord.nidaren.net"
-LABEL       org.label-schema.vcs-url="https://github.com/nidaren/docker-images"
-LABEL       org.label-schema.vendor="nidaren"
-LABEL       org.label-schema.version="1.5"
+LABEL       org.opencontainers.image.created=$BUILD_DATE \
+            org.opencontainers.image.authors="Nidaren" \
+            org.opencontainers.image.url="https://discord.nidaren.net" \
+            org.opencontainers.image.documentation="https://github.com/nidaren/docker-images" \
+            org.opencontainers.image.source="https://github.com/nidaren/docker-images" \
+            org.opencontainers.image.version="1.6" \
+            org.opencontainers.image.vendor="Nidaren" \
+            org.opencontainers.image.title="Eco Server Container" \
+            org.opencontainers.image.description="Contains environment to run various mods for Eco game server."
 
 RUN         dpkg --add-architecture i386 \
             && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \

--- a/eco/environment/build-docker-image.sh
+++ b/eco/environment/build-docker-image.sh
@@ -1,1 +1,1 @@
-docker build --no-cache=true --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -t nidaren/eco-server:environment .
+docker build --no-cache --pull --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -t nidaren/eco-server:environment .

--- a/eco/environment/files/entrypoint.sh
+++ b/eco/environment/files/entrypoint.sh
@@ -6,46 +6,82 @@ ENDCOLOR="\e[0m"
 CYAN='\033[0;36m'
 YELLOW='\033[0;33m'
 BLUE='\033[0;34m'
-OINT=/home/container/server/Mods/Chronicler/SQLite.Interop.dll
+NICEC="\e[38;5;219m"
+NICEC2="\e[38;5;223m"
+NID_DEB=$(. /etc/os-release; echo "$NAME")
+NID_DEBVER=$(cat /etc/debian_version)
+NID_DEBEDI=$(. /etc/os-release; echo "$VERSION_CODENAME")
 S32D=/home/container/.steam/sdk32/steamclient.so
 S64D=/home/container/.steam/sdk64/steamclient.so
 alreadyUpdated=false
 EcoServer=/home/container/server/EcoServer
+
+fix_interop() {
+  echo -e "${YELLOW}Checking for${ENDCOLOR} ${GREEN}incompatible${ENDCOLOR} ${YELLOW}files.${ENDCOLOR}"
+  find "$HOME" -type f -name "SQLite.Interop.dll" \
+    -exec sh -c 'echo "Deleting incompatible: $1"; rm "$1"' _ {} \;
+}
+
+steamInit(){
+    # need to run just for steamcmd update otherwise it gets sometimes stuck on getting user info
+    echo -e "${NICEC}STEAM INIT AND SELF UPDATE, PLEASE WAIT ...${ENDCOLOR}"
+
+    if [ "$STEAM_FEEDBACK" = true ]; then
+      /home/container/steamcmd/steamcmd.sh +login anonymous +quit
+    else
+      mkdir -p /home/container/server/Logs
+      /home/container/steamcmd/steamcmd.sh +login anonymous +quit > /home/container/server/Logs/steamLatest.log 2>&1
+
+    fi
+}
 
 runSteam()
 {
     echo -e "${YELLOW}Running Steam.${ENDCOLOR}"
     echo -e "${GREEN}Steam update log will be available in${ENDCOLOR} ${CYAN}steamLatest.log ${ENDCOLOR}"
     echo -e "${YELLOW}PLEASE WAIT ...${ENDCOLOR}"
+
+    if [ ! -f "$S32D" ]; then
+    	echo "Linking 32 bit steam dependencies."
+    	ln -s /home/container/steamcmd/linux32/steamclient.so /home/container/.steam/sdk32/steamclient.so
+    fi
+
+    if [ ! -f "$S64D" ]; then
+    	echo "Linking 64 bit steam dependencies."
+       ln -s /home/container/steamcmd/linux64/steamclient.so /home/container/.steam/sdk64/steamclient.so
+    fi
+
     if [ "$STEAM_FEEDBACK" = true ]; then
+         echo -e "${NICEC2}=========================================================${ENDCOLOR}"
+         echo -e "${NICEC}APP UPDATE CHECK ...${ENDCOLOR}"
          /home/container/steamcmd/steamcmd.sh +force_install_dir /home/container/server +login anonymous \
          $( [[ "${WINDOWS_INSTALL}" == "1" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) \
          +app_update 739590 -beta ${VERSION_BRANCH} validate +quit
       else
          mkdir -p /home/container/server/Logs
+
+         echo -e "App update check"
          /home/container/steamcmd/steamcmd.sh +force_install_dir /home/container/server +login anonymous \
          $( [[ "${WINDOWS_INSTALL}" == "1" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) \
-         +app_update 739590 -beta ${VERSION_BRANCH} validate +quit > /home/container/server/Logs/steamLatest.log
-    fi
-
-    if [ ! -f "$S32D" ]; then
-    echo "Linking 32 bit steam dependencies."
-    ln -s /home/container/steamcmd/linux32/steamclient.so /home/container/.steam/sdk32/steamclient.so
-    fi
-
-    if [ ! -f "$S64D" ]; then
-    echo "Linking 64 bit steam dependencies."
-    ln -s /home/container/steamcmd/linux64/steamclient.so /home/container/.steam/sdk64/steamclient.so
+         +app_update 739590 -beta ${VERSION_BRANCH} validate +quit > /home/container/server/Logs/steamLatest.log 2>&1
     fi
 
     echo -e "${BLUE}Completed.${ENDCOLOR}"
     echo -e "${YELLOW}Steam completed its operations.${ENDCOLOR}"
 }
 
+echo -e "${YELLOW}=========================================================${ENDCOLOR}"
+echo -e "Container's OS:     ${GREEN}${NID_DEB}${ENDCOLOR} ${NICE2}${NID_DEBEDI^}${ENDCOLOR}${NICEC} ${NID_DEBVER}${ENDCOLOR}"
+echo -e "Container's Layout: by ${GREEN}nidaren (c) 2026${ENDCOLOR}"
+echo -e "Support link:       ${NICEC}https://discord.nidaren.net${ENDCOLOR}"
+echo -e "${YELLOW}=========================================================${ENDCOLOR}"
+
 #case $VERSION_BRANCH in
 #    release|staging|playtest) echo -e "${YELLOW}Selected branch is:${ENDCOLOR} ${BLUE}$VERSION_BRANCH${ENDCOLOR}" ;;
 #    *) echo "VERSION_BRANCH must be: release, staging or playtest." && exit 1 ;;
 #esac
+
+steamInit
 
 if [ ! -f "$EcoServer" ]; then
     echo -e "${YELLOW}EcoServer does not exist. Will download.${ENDCOLOR}"
@@ -63,14 +99,9 @@ if [ "$FORCE_CHECK" = true ]; then
     runSteam
 fi
 
-OINT=/home/container/server/Mods/Chronicler/SQLite.Interop.dll
-
-if [ -f "$OINT" ]; then
-    echo -e "${YELLOW}Redundant Interlop dll removed from Chronicler.${ENDCOLOR}"
-    rm "$OINT"
-fi
+fix_interop
 
 cd /home/container/server
 
-echo -e "${BLUE}Server will now start."
+echo -e "${NICEC}Server will now start.${ENDCOLOR}"
 exec ./EcoServer -userToken="${ECO_TOKEN}"

--- a/eco/environment/push-docker-image.sh
+++ b/eco/environment/push-docker-image.sh
@@ -1,1 +1,1 @@
-docker push nidaren/eco-server:environment
+docker push nidaren/eco-server:environment-staging


### PR DESCRIPTION
Updated Debian to 12.12.
Updated new labels scheme. 
Added logic to remove incompatible SQLite.Interop.dll when placed somewhere in the container.
Added display headers to feedback.